### PR TITLE
Updating winrm to overcome a CVE

### DIFF
--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'erubi', '>= 1.7'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'rubyzip', '~> 2.0'
-  s.add_runtime_dependency 'winrm', '~> 2.0'
+  s.add_runtime_dependency 'chef-winrm', '>= 2.3.10'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake', '>= 10.3', '< 13'
+  s.add_development_dependency 'rake', '>= 13.2.1'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 1.26.0'
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We had to fork winrm and add our updates to it to get past a CVE in rexml and nori. Here we pull in the updated chef-winrm gem. Rake was too old and had to be updated as well.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
